### PR TITLE
Incorrect link when no plan is active

### DIFF
--- a/pages/account.tsx
+++ b/pages/account.tsx
@@ -103,7 +103,7 @@ export default function Account({ user }: { user: User }) {
             ) : subscription ? (
               `${subscriptionPrice}/${subscription?.prices?.interval}`
             ) : (
-              <Link href="/">
+              <Link href="/plans">
                 <a>Choose your plan</a>
               </Link>
             )}


### PR DESCRIPTION
When user has signed up, but has not purchased any plan, they see "Choose your plan" link in their Account page. However, "Choose your plan" currently is "href=/", but should be ☞ "href=/plans". Hope this helps!